### PR TITLE
feat: add IP threat score decay over time (#9)

### DIFF
--- a/src/Models/IpBehavior.php
+++ b/src/Models/IpBehavior.php
@@ -113,4 +113,57 @@ class IpBehavior extends Model
                 'login_attempts' => 0,
             ]);
     }
+
+    /**
+     * Apply threat score decay based on inactivity time.
+     * Reduces score gradually for IPs that have stopped suspicious activity.
+     *
+     * @param  float  $decayRate  Points to subtract per decay interval
+     * @param  int  $decayIntervalMinutes  Minutes of inactivity before decay applies
+     * @return bool Whether the score was actually decayed
+     */
+    public function decayThreatScore(float $decayRate = 5.0, int $decayIntervalMinutes = 60): bool
+    {
+        if ($this->threat_score <= 0) {
+            return false;
+        }
+
+        $minutesSinceLastActivity = $this->last_activity
+            ? now()->diffInMinutes($this->last_activity)
+            : 0;
+
+        if ($minutesSinceLastActivity < $decayIntervalMinutes) {
+            return false;
+        }
+
+        // Calculate number of decay intervals passed
+        $intervals = (int) floor($minutesSinceLastActivity / $decayIntervalMinutes);
+        $totalDecay = $decayRate * $intervals;
+
+        $newScore = max(0, $this->threat_score - $totalDecay);
+        $this->update(['threat_score' => $newScore]);
+
+        return true;
+    }
+
+    /**
+     * Apply decay to all behaviors that have been inactive.
+     *
+     * @return int Number of records decayed
+     */
+    public static function applyDecayAll(float $decayRate = 5.0, int $decayIntervalMinutes = 60): int
+    {
+        $decayed = 0;
+        $candidates = static::where('threat_score', '>', 0)
+            ->where('last_activity', '<', now()->subMinutes($decayIntervalMinutes))
+            ->get();
+
+        foreach ($candidates as $behavior) {
+            if ($behavior->decayThreatScore($decayRate, $decayIntervalMinutes)) {
+                $decayed++;
+            }
+        }
+
+        return $decayed;
+    }
 }


### PR DESCRIPTION
## Summary

Implementasi mekanisme threat score decay agar IP yang sudah berhenti melakukan aktivitas mencurigakan otomatis mendapat pengurangan threat score.

Closes #9

## Changes

- `src/Models/IpBehavior.php`:
  - `decayThreatScore($rate, $interval)` — decay individual IP
  - `applyDecayAll($rate, $interval)` — batch decay semua IP inaktif
  - Default: -5 per 60 menit inaktif

## Testing

- [x] All 77 tests pass

## Checklist

- [x] Code mengikuti konvensi project
- [x] Tidak ada perubahan yang tidak terkait
