### PR TITLE
feat: add notification support (#8)

### DIFF
--- a/config/crowdsec-scenarios.php
+++ b/config/crowdsec-scenarios.php
@@ -439,4 +439,16 @@ return [
         'ttl' => env('CROWDSEC_CACHE_TTL', 60), // seconds
         'prefix' => 'crowdsec',
     ],
+
+    // =========================================================================
+    // NOTIFICATIONS
+    // =========================================================================
+
+    'notifications' => [
+        'enabled' => env('CROWDSEC_NOTIFY_ENABLED', false),
+        'channels' => ['mail'], // Supported: 'mail', 'slack'
+        'severity_threshold' => 'high', // Only notify for this severity and above
+        'rate_limit_minutes' => 5, // Max 1 notification per IP per N minutes
+        'recipients' => explode(',', env('CROWDSEC_NOTIFY_RECIPIENTS', '')),
+    ],
 ];

--- a/src/CrowdSecServiceProvider.php
+++ b/src/CrowdSecServiceProvider.php
@@ -73,6 +73,12 @@ class CrowdSecServiceProvider extends ServiceProvider
 
         // Register scheduled cleanup tasks (Laravel 11+ style)
         $this->registerScheduledCleanup();
+
+        // Register event listeners for notifications
+        Event::listen(
+            \RiloArbabillah\LaravelCrowdSec\Events\IpBlocked::class,
+            \RiloArbabillah\LaravelCrowdSec\Listeners\SendSecurityAlert::class
+        );
     }
 
     /**

--- a/src/Listeners/SendSecurityAlert.php
+++ b/src/Listeners/SendSecurityAlert.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace RiloArbabillah\LaravelCrowdSec\Listeners;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Notification;
+use RiloArbabillah\LaravelCrowdSec\Events\IpBlocked;
+use RiloArbabillah\LaravelCrowdSec\Notifications\SecurityAlertNotification;
+
+class SendSecurityAlert
+{
+    /**
+     * Handle the IpBlocked event.
+     */
+    public function handle(IpBlocked $event): void
+    {
+        $config = config('crowdsec-scenarios.notifications', []);
+
+        if (! ($config['enabled'] ?? false)) {
+            return;
+        }
+
+        // Only notify for configured severity levels
+        $severityThreshold = $config['severity_threshold'] ?? 'high';
+        $severityWeights = ['low' => 1, 'medium' => 2, 'high' => 3, 'critical' => 4];
+
+        // Derive severity from event type
+        $scenarios = config('crowdsec-scenarios', []);
+        $severity = 'medium';
+        if ($event->eventType && isset($scenarios[$event->eventType]['severity'])) {
+            $severity = $scenarios[$event->eventType]['severity'];
+        }
+
+        if (($severityWeights[$severity] ?? 0) < ($severityWeights[$severityThreshold] ?? 3)) {
+            return;
+        }
+
+        // Rate limiting: max 1 notification per IP per 5 minutes
+        $rateLimitMinutes = $config['rate_limit_minutes'] ?? 5;
+        $cacheKey = "crowdsec:notify:{$event->ip}";
+
+        if (Cache::has($cacheKey)) {
+            return;
+        }
+
+        Cache::put($cacheKey, true, now()->addMinutes($rateLimitMinutes));
+
+        // Send notification
+        $recipients = $config['recipients'] ?? [];
+        if (empty($recipients)) {
+            return;
+        }
+
+        $notification = new SecurityAlertNotification(
+            ip: $event->ip,
+            reason: $event->reason,
+            severity: $severity,
+            context: [
+                'duration_minutes' => $event->durationMinutes,
+                'block_count' => $event->blockCount,
+                'event_type' => $event->eventType,
+            ]
+        );
+
+        Notification::route('mail', $recipients)
+            ->notify($notification);
+    }
+}

--- a/src/Notifications/SecurityAlertNotification.php
+++ b/src/Notifications/SecurityAlertNotification.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace RiloArbabillah\LaravelCrowdSec\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Notification;
+
+class SecurityAlertNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public string $ip,
+        public string $reason,
+        public string $severity,
+        public array $context = [],
+    ) {}
+
+    /**
+     * Get the notification's delivery channels.
+     */
+    public function via(object $notifiable): array
+    {
+        return config('crowdsec-scenarios.notifications.channels', ['mail']);
+    }
+
+    /**
+     * Get the mail representation.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject("[CrowdSec] {$this->severity} security alert: {$this->reason}")
+            ->greeting('🛡️ CrowdSec Security Alert')
+            ->line("**Severity:** {$this->severity}")
+            ->line("**IP Address:** {$this->ip}")
+            ->line("**Reason:** {$this->reason}")
+            ->line('**Time:** ' . now()->toDateTimeString())
+            ->when(! empty($this->context), function ($message) {
+                $message->line('**Context:** ' . json_encode($this->context, JSON_PRETTY_PRINT));
+            })
+            ->action('View Dashboard', url('/'))
+            ->line('This is an automated security notification.');
+    }
+
+    /**
+     * Get the Slack representation.
+     */
+    public function toSlack(object $notifiable): SlackMessage
+    {
+        return (new SlackMessage)
+            ->error()
+            ->content("🛡️ CrowdSec: {$this->severity} alert — {$this->reason}")
+            ->attachment(function ($attachment) {
+                $attachment
+                    ->title('Security Alert')
+                    ->fields([
+                        'IP' => $this->ip,
+                        'Severity' => $this->severity,
+                        'Reason' => $this->reason,
+                        'Time' => now()->toDateTimeString(),
+                    ]);
+            });
+    }
+
+    /**
+     * Get the array representation (for database/broadcast).
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'ip' => $this->ip,
+            'reason' => $this->reason,
+            'severity' => $this->severity,
+            'context' => $this->context,
+            'timestamp' => now()->toISOString(),
+        ];
+    }
+}

--- a/src/Services/CrowdSecService.php
+++ b/src/Services/CrowdSecService.php
@@ -36,6 +36,7 @@ class CrowdSecService
         'enabled', 'blocked_response_message', 'log_channel',
         'max_content_length', 'block_empty_ua', 'blocked_methods',
         'cache',
+        'notifications',
     ];
 
     public function __construct()


### PR DESCRIPTION
## Summary

Tambahkan notification support untuk mengirim alert saat critical threat terdeteksi.

Closes #8

## Changes

- `src/Notifications/SecurityAlertNotification.php` (mail, Slack, array)
- `src/Listeners/SendSecurityAlert.php` (severity filtering, rate limiting)
- `src/CrowdSecServiceProvider.php` (listener registration)
- `config/crowdsec-scenarios.php` (notifications section)
- `src/Services/CrowdSecService.php` (add 'notifications' to NON_SCENARIO_KEYS)

## Testing

- [x] All 77 tests pass

## Checklist

- [x] Code mengikuti konvensi project
- [x] Tidak ada perubahan yang tidak terkait
