### PR TITLE
feat: add honeypot route trap middleware (#16)

### DIFF
--- a/config/crowdsec-scenarios.php
+++ b/config/crowdsec-scenarios.php
@@ -451,4 +451,22 @@ return [
         'rate_limit_minutes' => 5, // Max 1 notification per IP per N minutes
         'recipients' => explode(',', env('CROWDSEC_NOTIFY_RECIPIENTS', '')),
     ],
+
+    // =========================================================================
+    // HONEYPOT ROUTES
+    // =========================================================================
+
+    // Routes that serve as traps for malicious scanners.
+    // Any request to these routes will immediately block the IP.
+    'honeypot_routes' => [
+        '.env',
+        'wp-admin',
+        'wp-login.php',
+        'wp-includes',
+        'xmlrpc.php',
+        'phpmyadmin',
+        'administrator',
+        '.git/config',
+        '.well-known/security.txt',
+    ],
 ];

--- a/src/CrowdSecServiceProvider.php
+++ b/src/CrowdSecServiceProvider.php
@@ -52,6 +52,7 @@ class CrowdSecServiceProvider extends ServiceProvider
         // Register middleware
         $router = $this->app['router'];
         $router->aliasMiddleware('crowdsec', CrowdSecProtection::class);
+        $router->aliasMiddleware('crowdsec.honeypot', \RiloArbabillah\LaravelCrowdSec\Http\Middleware\HoneypotTrap::class);
 
         // Listen for successful authentication to unblock IP and reset login attempts
         Event::listen(Authenticated::class, function (Authenticated $event) {

--- a/src/Http/Middleware/HoneypotTrap.php
+++ b/src/Http/Middleware/HoneypotTrap.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace RiloArbabillah\LaravelCrowdSec\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use RiloArbabillah\LaravelCrowdSec\Services\CrowdSecService;
+
+class HoneypotTrap
+{
+    public function __construct(
+        protected CrowdSecService $service,
+    ) {}
+
+    /**
+     * Handle an incoming request.
+     * Block any request that hits a honeypot route.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $honeypotRoutes = config('crowdsec-scenarios.honeypot_routes', []);
+
+        if (empty($honeypotRoutes)) {
+            return $next($request);
+        }
+
+        $path = ltrim($request->path(), '/');
+
+        foreach ($honeypotRoutes as $route) {
+            $route = ltrim($route, '/');
+
+            if ($path === $route || str_starts_with($path, $route . '/')) {
+                $ip = $request->ip() ?? 'unknown';
+
+                // Block immediately — honeypot access is always malicious
+                $this->service->blockIp($ip, 'Honeypot trap triggered', null, 'honeypot_trap');
+
+                // Log the event
+                $this->service->logEvent($ip, [
+                    [
+                        'type' => 'honeypot_trap',
+                        'severity' => 'critical',
+                        'pattern' => $route,
+                        'matched' => $path,
+                    ],
+                ], $request);
+
+                return new Response(
+                    config('crowdsec-scenarios.blocked_response_message', 'Access denied'),
+                    403
+                );
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Services/CrowdSecService.php
+++ b/src/Services/CrowdSecService.php
@@ -37,6 +37,7 @@ class CrowdSecService
         'max_content_length', 'block_empty_ua', 'blocked_methods',
         'cache',
         'notifications',
+        'honeypot_routes',
     ];
 
     public function __construct()


### PR DESCRIPTION
## Summary

Tambahkan honeypot route trap middleware.

Closes #16

## Changes

- `src/Http/Middleware/HoneypotTrap.php` — blocks any request to trap routes
- `crowdsec.honeypot` middleware alias registered
- `honeypot_routes` config with common scanner paths (wp-admin, .env, phpmyadmin, etc.)

## Testing

- [x] All 77 tests pass

## Checklist

- [x] Code mengikuti konvensi project
