### PR TITLE
feat: add admin security dashboard (#12)

### DIFF
--- a/config/crowdsec-scenarios.php
+++ b/config/crowdsec-scenarios.php
@@ -489,4 +489,14 @@ return [
         'enabled' => env('CROWDSEC_API_ENABLED', false),
         'middleware' => ['api'], // Add 'auth:sanctum' for production
     ],
+
+    // =========================================================================
+    // ADMIN DASHBOARD
+    // =========================================================================
+
+    'dashboard' => [
+        'enabled' => env('CROWDSEC_DASHBOARD_ENABLED', false),
+        'path' => 'crowdsec', // Dashboard URL path
+        'middleware' => ['web'], // Add 'auth' for production
+    ],
 ];

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CrowdSec Security Dashboard</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0f172a; color: #e2e8f0; }
+        .container { max-width: 1200px; margin: 0 auto; padding: 24px; }
+        h1 { font-size: 24px; margin-bottom: 24px; display: flex; align-items: center; gap: 8px; }
+        h1 span { font-size: 28px; }
+        .grid { display: grid; gap: 16px; margin-bottom: 24px; }
+        .grid-4 { grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+        .grid-2 { grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); }
+        .card { background: #1e293b; border-radius: 12px; padding: 20px; border: 1px solid #334155; }
+        .card h2 { font-size: 14px; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
+        .card .value { font-size: 32px; font-weight: 700; }
+        .card .label { font-size: 12px; color: #64748b; margin-top: 4px; }
+        .section-title { font-size: 16px; margin-bottom: 12px; color: #cbd5e1; }
+        table { width: 100%; border-collapse: collapse; }
+        th { text-align: left; padding: 10px 12px; font-size: 12px; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.5px; border-bottom: 1px solid #334155; }
+        td { padding: 10px 12px; font-size: 14px; border-bottom: 1px solid #1e293b; }
+        tr:hover { background: #334155; }
+        .badge { padding: 2px 8px; border-radius: 9999px; font-size: 11px; font-weight: 600; }
+        .badge-critical { background: #991b1b; color: #fca5a5; }
+        .badge-high { background: #92400e; color: #fcd34d; }
+        .badge-medium { background: #1e3a5f; color: #93c5fd; }
+        .badge-low { background: #064e3b; color: #6ee7b7; }
+        .text-green { color: #4ade80; }
+        .text-red { color: #f87171; }
+        .text-yellow { color: #fbbf24; }
+        .text-blue { color: #60a5fa; }
+        .footer { text-align: center; padding: 24px; color: #475569; font-size: 12px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1><span>🛡️</span> CrowdSec Security Dashboard</h1>
+
+        {{-- Stats Cards --}}
+        <div class="grid grid-4">
+            <div class="card">
+                <h2>Events Today</h2>
+                <div class="value text-blue">{{ $stats['events_today'] }}</div>
+                <div class="label">Total: {{ $stats['total_events'] }}</div>
+            </div>
+            <div class="card">
+                <h2>This Week</h2>
+                <div class="value text-yellow">{{ $stats['events_this_week'] }}</div>
+                <div class="label">Security events</div>
+            </div>
+            <div class="card">
+                <h2>Active Blocks</h2>
+                <div class="value text-red">{{ $stats['active_blocks'] }}</div>
+                <div class="label">Currently blocked IPs</div>
+            </div>
+            <div class="card">
+                <h2>High Threat</h2>
+                <div class="value text-green">{{ $stats['high_threat_ips'] }}</div>
+                <div class="label">of {{ $stats['total_ips_tracked'] }} tracked</div>
+            </div>
+        </div>
+
+        {{-- Threat Breakdown --}}
+        @if(!empty($threatBreakdown))
+        <div class="card" style="margin-bottom: 24px;">
+            <h2>Threat Breakdown (Last 7 Days)</h2>
+            <div style="display: flex; gap: 16px; margin-top: 12px; flex-wrap: wrap;">
+                @foreach($threatBreakdown as $severity => $count)
+                <div style="text-align: center;">
+                    <span class="badge badge-{{ $severity ?? 'medium' }}">{{ strtoupper($severity ?? 'unknown') }}</span>
+                    <div style="font-size: 20px; font-weight: 600; margin-top: 4px;">{{ $count }}</div>
+                </div>
+                @endforeach
+            </div>
+        </div>
+        @endif
+
+        {{-- Tables --}}
+        <div class="grid grid-2">
+            {{-- Recent Events --}}
+            <div class="card">
+                <h2>Recent Events</h2>
+                <table>
+                    <thead>
+                        <tr><th>IP</th><th>Type</th><th>Severity</th><th>Time</th></tr>
+                    </thead>
+                    <tbody>
+                        @forelse($recentEvents as $event)
+                        <tr>
+                            <td>{{ $event->ip }}</td>
+                            <td>{{ $event->event_type ?? '-' }}</td>
+                            <td><span class="badge badge-{{ $event->severity ?? 'medium' }}">{{ $event->severity ?? '-' }}</span></td>
+                            <td>{{ $event->created_at->diffForHumans() }}</td>
+                        </tr>
+                        @empty
+                        <tr><td colspan="4" style="text-align:center; color:#64748b;">No events recorded</td></tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+
+            {{-- Blocked IPs --}}
+            <div class="card">
+                <h2>Blocked IPs</h2>
+                <table>
+                    <thead>
+                        <tr><th>IP</th><th>Reason</th><th>Expires</th></tr>
+                    </thead>
+                    <tbody>
+                        @forelse($blockedIps as $blocked)
+                        <tr>
+                            <td>{{ $blocked->ip }}</td>
+                            <td>{{ Str::limit($blocked->reason, 30) }}</td>
+                            <td>{{ $blocked->expires_at ? $blocked->expires_at->diffForHumans() : 'Never' }}</td>
+                        </tr>
+                        @empty
+                        <tr><td colspan="3" style="text-align:center; color:#64748b;">No blocked IPs</td></tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        {{-- Top Attackers --}}
+        @if($topAttackers->isNotEmpty())
+        <div class="card" style="margin-top: 24px;">
+            <h2>Top Attackers (Last 24h)</h2>
+            <table>
+                <thead>
+                    <tr><th>#</th><th>IP Address</th><th>Events</th></tr>
+                </thead>
+                <tbody>
+                    @foreach($topAttackers as $index => $attacker)
+                    <tr>
+                        <td>{{ $index + 1 }}</td>
+                        <td>{{ $attacker->ip }}</td>
+                        <td>{{ $attacker->count }}</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+        @endif
+
+        <div class="footer">
+            CrowdSec for Laravel — Powered by rilo-arbabillah/laravel-crowdsec
+        </div>
+    </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use RiloArbabillah\LaravelCrowdSec\Http\Controllers\CrowdSecDashboardController;
+
+Route::prefix(config('crowdsec-scenarios.dashboard.path', 'crowdsec'))
+    ->middleware(config('crowdsec-scenarios.dashboard.middleware', ['web']))
+    ->group(function () {
+        Route::get('/', [CrowdSecDashboardController::class, 'index'])->name('crowdsec.dashboard');
+    });

--- a/src/CrowdSecServiceProvider.php
+++ b/src/CrowdSecServiceProvider.php
@@ -49,6 +49,19 @@ class CrowdSecServiceProvider extends ServiceProvider
             $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
         }
 
+        // Load dashboard routes (if enabled)
+        if (config('crowdsec-scenarios.dashboard.enabled', false)) {
+            $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
+        }
+
+        // Register views
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'crowdsec');
+
+        // Publish views
+        $this->publishes([
+            __DIR__.'/../resources/views' => resource_path('views/vendor/crowdsec'),
+        ], 'crowdsec-views');
+
         // Register commands
         if ($this->app->runningInConsole()) {
             $this->commands([

--- a/src/Http/Controllers/CrowdSecDashboardController.php
+++ b/src/Http/Controllers/CrowdSecDashboardController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace RiloArbabillah\LaravelCrowdSec\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use RiloArbabillah\LaravelCrowdSec\Models\BlockedIp;
+use RiloArbabillah\LaravelCrowdSec\Models\IpBehavior;
+use RiloArbabillah\LaravelCrowdSec\Models\SecurityEvent;
+
+class CrowdSecDashboardController extends Controller
+{
+    /**
+     * Display the security dashboard.
+     */
+    public function index()
+    {
+        $stats = [
+            'total_events' => SecurityEvent::count(),
+            'events_today' => SecurityEvent::where('created_at', '>=', now()->startOfDay())->count(),
+            'events_this_week' => SecurityEvent::where('created_at', '>=', now()->startOfWeek())->count(),
+            'active_blocks' => BlockedIp::active()->count(),
+            'total_ips_tracked' => IpBehavior::count(),
+            'high_threat_ips' => IpBehavior::highThreat()->count(),
+        ];
+
+        $recentEvents = SecurityEvent::orderBy('created_at', 'desc')
+            ->limit(20)
+            ->get();
+
+        $blockedIps = BlockedIp::active()
+            ->orderBy('created_at', 'desc')
+            ->limit(20)
+            ->get();
+
+        $topAttackers = SecurityEvent::selectRaw('ip, COUNT(*) as count')
+            ->where('created_at', '>=', now()->subDay())
+            ->groupBy('ip')
+            ->orderByDesc('count')
+            ->limit(10)
+            ->get();
+
+        $threatBreakdown = SecurityEvent::selectRaw('severity, COUNT(*) as count')
+            ->where('created_at', '>=', now()->subWeek())
+            ->groupBy('severity')
+            ->get()
+            ->pluck('count', 'severity')
+            ->toArray();
+
+        return view('crowdsec::dashboard', compact(
+            'stats',
+            'recentEvents',
+            'blockedIps',
+            'topAttackers',
+            'threatBreakdown'
+        ));
+    }
+}

--- a/src/Services/CrowdSecService.php
+++ b/src/Services/CrowdSecService.php
@@ -40,6 +40,7 @@ class CrowdSecService
         'honeypot_routes',
         'geoip',
         'api',
+        'dashboard',
     ];
 
     public function __construct()


### PR DESCRIPTION
## Summary

Tambahkan admin security dashboard.

Closes #12

## Changes

- `src/Http/Controllers/CrowdSecDashboardController.php` — stats, events, blocks, top attackers
- `resources/views/dashboard.blade.php` — dark theme, standalone (no external CSS)
- `routes/web.php` — dashboard route
- Dashboard config di `config/crowdsec-scenarios.php`
- Dashboard disabled by default (enable via `CROWDSEC_DASHBOARD_ENABLED=true`)
- Publishable views via `crowdsec-views` tag

## Testing

- [x] All 77 tests pass

## Checklist

- [x] Code mengikuti konvensi project
