### PR TITLE
chore: prepare v1.0.0 stable release (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-03-11
+
+### Added
+
+- **WAF Pattern Detection** — 15 attack types with 100+ regex patterns
+  - SQL Injection, XSS, Path Traversal, Command Injection
+  - SSRF, XXE, NoSQL Injection, LDAP Injection, SSTI
+  - Open Redirect, File Inclusion, PHP Serialization
+  - Directory Bruteforce, Header Injection, Suspicious User Agent
+- **IP Blocking** — temporary blocks with automatic expiration
+- **Progressive Escalation** — block duration doubles per re-offense (max 7 days)
+- **Behavior Tracking** — request rate, 404 errors, login attempts, threat score
+- **Multi-Layer Decoding** — URL decode (single/double) + HTML entity decode
+- **IP Whitelist** — exact match + CIDR notation support
+- **Login Route Detection** — brute-force protection for configured login routes
+- **Caching Layer** — cached blocked IP lookups via Laravel Cache (PR #22)
+- **Event System** — 4 Laravel events: ThreatDetected, IpBlocked, IpUnblocked, BehaviorThresholdExceeded (PR #25)
+- **Notification Support** — email/Slack alerts with severity filtering and rate limiting (PR #26)
+- **IP Threat Score Decay** — gradual score reduction for inactive IPs (PR #24)
+- **Scheduled Cleanup** — auto-registration of cleanup commands (PR #23)
+- **Custom Pattern Plugin** — `registerScenario()` for runtime pattern registration (PR #27)
+- **Honeypot Route Trap** — `crowdsec.honeypot` middleware for scanner detection (PR #28)
+- **Per-Route Rate Limiting** — `crowdsec.rate:60,1` middleware (PR #29)
+- **SIEM Export** — `crowdsec:export` command with JSON, CSV, Syslog (RFC 5424) formats (PR #30)
+- **GeoIP Lookup** — ip-api.com provider with 24h caching (PR #31)
+- **REST API** — 6 endpoints for programmatic management (PR #32)
+- **Admin Dashboard** — standalone Blade dashboard with dark theme (PR #33)
+- **CLI Commands** — `crowdsec:stats`, `crowdsec:cleanup`, `crowdsec:export`
+- **Facade API** — `CrowdSec::blockIp()`, `isBlocked()`, `unblockIp()`, `analyzeRequest()`
+- **Auto-Migration** — 3 database tables created automatically
+- **GitHub Actions CI** — PHP 8.1/8.2/8.3 × Laravel 10.x/11.x matrix (PR #18)
+
+### Security
+
+- **ReDoS Protection** — `safeMatch()` wrapper with pcre.backtrack_limit=10,000 and 8KB input truncation (PR #43)
+- **Tightened Patterns** — replaced risky `.*` quantifiers with bounded `[^x]{0,200}` alternatives
+- **Fail-Open Design** — WAF errors never crash the application
+
+### Testing
+
+- 136 tests with 202 assertions
+- 27 unit tests, 22 integration tests, 20 edge case tests
+- 8 performance benchmarks (all <1ms)
+- 45 new feature tests (PR #42)
+- 14 ReDoS resistance tests (PR #43)
+
+## [1.0.0-alpha] - 2026-03-08
+
+### Added
+
+- Initial release with core WAF detection (12 attack types)
+- IP blocking with expiration
+- Behavior tracking
+- CLI commands (stats, cleanup)
+- Facade API
+- 27 unit tests

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A lightweight CrowdSec-like WAF protection package for Laravel",
     "type": "library",
     "license": "MIT",
-    "version": "1.0.0-alpha",
+    "version": "1.0.0",
     "require": {
         "php": "^8.1",
         "illuminate/contracts": "^10.0|^11.0",
@@ -42,7 +42,7 @@
         "optimize-autoloader": true,
         "sort-packages": true
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "scripts": {
         "test": "phpunit"


### PR DESCRIPTION
## Summary

Prepare v1.0.0 stable release.

Closes #38

## Changes

- Bump `composer.json` version from `1.0.0-alpha` to `1.0.0`
- Change `minimum-stability` from `dev` to `stable`
- Add `CHANGELOG.md` documenting all features, security improvements, and tests

## Testing

- [x] All 136 tests pass (202 assertions)
- [x] No breaking changes
