### PR TITLE
feat: add Laravel 12 compatibility support (#35)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,12 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [10.*, 11.*]
+        laravel: [10.*, 11.*, 12.*]
         exclude:
           - php: 8.1
             laravel: 11.*
+          - php: 8.1
+            laravel: 12.*
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -6,16 +6,16 @@
     "version": "1.0.0",
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^10.0|^11.0",
-        "illuminate/database": "^10.0|^11.0",
-        "illuminate/http": "^10.0|^11.0",
-        "illuminate/support": "^10.0|^11.0",
-        "illuminate/console": "^10.0|^11.0"
+        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "illuminate/database": "^10.0|^11.0|^12.0",
+        "illuminate/http": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/console": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.10",
         "guzzlehttp/psr7": "^2.9",
-        "orchestra/testbench": "^8.0|^9.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
         "phpunit/phpunit": "^10.0|^11.0"
     },
     "autoload": {


### PR DESCRIPTION
## Summary\n\nAdd Laravel 12 compatibility.\n\nCloses #35\n\n## Changes\n- Add `^12.0` to all illuminate/* deps\n- Add `^10.0` to orchestra/testbench\n- Update CI matrix: add Laravel 12.* with PHP 8.2/8.3\n- Exclude PHP 8.1 + Laravel 12.*\n\n## Testing\n- [x] All 136 tests pass (202 assertions)