### PR TITLE
feat: add Prometheus/OpenMetrics metrics endpoint (#48)

### DIFF
--- a/config/crowdsec-scenarios.php
+++ b/config/crowdsec-scenarios.php
@@ -491,6 +491,16 @@ return [
     ],
 
     // =========================================================================
+    // PROMETHEUS METRICS
+    // =========================================================================
+
+    'metrics' => [
+        'enabled' => env('CROWDSEC_METRICS_ENABLED', false),
+        'path' => 'crowdsec/metrics', // Metrics endpoint URL path
+        'middleware' => ['api'], // Consider adding IP-based auth for production
+    ],
+
+    // =========================================================================
     // ADMIN DASHBOARD
     // =========================================================================
 

--- a/routes/metrics.php
+++ b/routes/metrics.php
@@ -1,0 +1,9 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use RiloArbabillah\LaravelCrowdSec\Http\Controllers\CrowdSecMetricsController;
+
+Route::get(
+    config('crowdsec-scenarios.metrics.path', 'crowdsec/metrics'),
+    CrowdSecMetricsController::class
+)->middleware(config('crowdsec-scenarios.metrics.middleware', ['api']));

--- a/src/CrowdSecServiceProvider.php
+++ b/src/CrowdSecServiceProvider.php
@@ -49,6 +49,11 @@ class CrowdSecServiceProvider extends ServiceProvider
             $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
         }
 
+        // Load metrics route (if enabled)
+        if (config('crowdsec-scenarios.metrics.enabled', false)) {
+            $this->loadRoutesFrom(__DIR__.'/../routes/metrics.php');
+        }
+
         // Load dashboard routes (if enabled)
         if (config('crowdsec-scenarios.dashboard.enabled', false)) {
             $this->loadRoutesFrom(__DIR__.'/../routes/web.php');

--- a/src/Http/Controllers/CrowdSecMetricsController.php
+++ b/src/Http/Controllers/CrowdSecMetricsController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace RiloArbabillah\LaravelCrowdSec\Http\Controllers;
+
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+use RiloArbabillah\LaravelCrowdSec\Models\BlockedIp;
+use RiloArbabillah\LaravelCrowdSec\Models\IpBehavior;
+use RiloArbabillah\LaravelCrowdSec\Models\SecurityEvent;
+
+class CrowdSecMetricsController extends Controller
+{
+    /**
+     * GET /crowdsec/metrics — Prometheus/OpenMetrics endpoint
+     */
+    public function __invoke(): Response
+    {
+        $lines = [];
+
+        // -- threats_total (counter) --
+        $lines[] = '# HELP crowdsec_threats_total Total number of threats detected';
+        $lines[] = '# TYPE crowdsec_threats_total counter';
+
+        $threatsByType = SecurityEvent::query()
+            ->selectRaw("event_type, severity, count(*) as total")
+            ->groupBy('event_type', 'severity')
+            ->get();
+
+        foreach ($threatsByType as $row) {
+            $type = $this->sanitizeLabel($row->event_type);
+            $severity = $this->sanitizeLabel($row->severity);
+            $lines[] = "crowdsec_threats_total{type=\"{$type}\",severity=\"{$severity}\"} {$row->total}";
+        }
+
+        // -- blocked_ips_active (gauge) --
+        $lines[] = '';
+        $lines[] = '# HELP crowdsec_blocked_ips_active Number of currently active blocked IPs';
+        $lines[] = '# TYPE crowdsec_blocked_ips_active gauge';
+        $lines[] = 'crowdsec_blocked_ips_active ' . BlockedIp::active()->count();
+
+        // -- blocked_ips_total (counter) --
+        $lines[] = '';
+        $lines[] = '# HELP crowdsec_blocked_ips_total Total number of IPs ever blocked';
+        $lines[] = '# TYPE crowdsec_blocked_ips_total counter';
+        $lines[] = 'crowdsec_blocked_ips_total ' . BlockedIp::count();
+
+        // -- tracked_ips (gauge) --
+        $lines[] = '';
+        $lines[] = '# HELP crowdsec_tracked_ips Number of IPs being tracked';
+        $lines[] = '# TYPE crowdsec_tracked_ips gauge';
+        $lines[] = 'crowdsec_tracked_ips ' . IpBehavior::count();
+
+        // -- high_threat_ips (gauge) --
+        $lines[] = '';
+        $lines[] = '# HELP crowdsec_high_threat_ips IPs with threat score above threshold';
+        $lines[] = '# TYPE crowdsec_high_threat_ips gauge';
+        $lines[] = 'crowdsec_high_threat_ips ' . IpBehavior::highThreat()->count();
+
+        // -- threat_score_average (gauge) --
+        $lines[] = '';
+        $lines[] = '# HELP crowdsec_threat_score_average Average threat score across all tracked IPs';
+        $lines[] = '# TYPE crowdsec_threat_score_average gauge';
+        $avg = IpBehavior::avg('threat_score') ?? 0;
+        $lines[] = 'crowdsec_threat_score_average ' . round((float) $avg, 2);
+
+        // -- events_today (gauge) --
+        $lines[] = '';
+        $lines[] = '# HELP crowdsec_events_today Number of security events today';
+        $lines[] = '# TYPE crowdsec_events_today gauge';
+        $lines[] = 'crowdsec_events_today ' . SecurityEvent::where('created_at', '>=', now()->startOfDay())->count();
+
+        // -- events_this_hour (gauge) --
+        $lines[] = '';
+        $lines[] = '# HELP crowdsec_events_this_hour Number of security events in the last hour';
+        $lines[] = '# TYPE crowdsec_events_this_hour gauge';
+        $lines[] = 'crowdsec_events_this_hour ' . SecurityEvent::where('created_at', '>=', now()->subHour())->count();
+
+        $lines[] = '';
+
+        return response(
+            implode("\n", $lines),
+            200,
+            ['Content-Type' => 'text/plain; version=0.0.4; charset=utf-8']
+        );
+    }
+
+    protected function sanitizeLabel(string $value): string
+    {
+        return preg_replace('/[^a-zA-Z0-9_]/', '_', $value);
+    }
+}

--- a/src/Services/CrowdSecService.php
+++ b/src/Services/CrowdSecService.php
@@ -40,6 +40,7 @@ class CrowdSecService
         'honeypot_routes',
         'geoip',
         'api',
+        'metrics',
         'dashboard',
     ];
 

--- a/tests/Feature/MetricsEndpointTest.php
+++ b/tests/Feature/MetricsEndpointTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace RiloArbabillah\LaravelCrowdSec\Tests\Feature;
+
+use Orchestra\Testbench\TestCase;
+use RiloArbabillah\LaravelCrowdSec\CrowdSecServiceProvider;
+use RiloArbabillah\LaravelCrowdSec\Models\BlockedIp;
+use RiloArbabillah\LaravelCrowdSec\Models\IpBehavior;
+use RiloArbabillah\LaravelCrowdSec\Models\SecurityEvent;
+
+class MetricsEndpointTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [CrowdSecServiceProvider::class];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set(
+            'crowdsec-scenarios',
+            require __DIR__ . '/../../config/crowdsec-scenarios.php'
+        );
+        $app['config']->set('crowdsec-scenarios.metrics.enabled', true);
+        $app['config']->set('crowdsec-scenarios.metrics.middleware', []);
+
+        $app['config']->set('database.default', 'testing');
+        $app['config']->set('database.connections.testing', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->loadMigrationsFrom(__DIR__ . '/../../src/Database/Migrations');
+    }
+
+    public function test_metrics_endpoint_returns_200(): void
+    {
+        $response = $this->get('/crowdsec/metrics');
+        $response->assertStatus(200);
+    }
+
+    public function test_metrics_endpoint_returns_openmetrics_content_type(): void
+    {
+        $response = $this->get('/crowdsec/metrics');
+        $response->assertHeader('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+    }
+
+    public function test_metrics_contains_threats_total(): void
+    {
+        SecurityEvent::create([
+            'ip' => '1.2.3.4',
+            'event_type' => 'sql_injection',
+            'severity' => 'critical',
+            'description' => 'test',
+        ]);
+
+        $response = $this->get('/crowdsec/metrics');
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('# HELP crowdsec_threats_total', $content);
+        $this->assertStringContainsString('# TYPE crowdsec_threats_total counter', $content);
+        $this->assertStringContainsString('crowdsec_threats_total{type="sql_injection",severity="critical"} 1', $content);
+    }
+
+    public function test_metrics_contains_blocked_ips_active(): void
+    {
+        BlockedIp::create([
+            'ip' => '5.6.7.8',
+            'reason' => 'test',
+            'blocked_until' => now()->addHour(),
+        ]);
+
+        $response = $this->get('/crowdsec/metrics');
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('# TYPE crowdsec_blocked_ips_active gauge', $content);
+        $this->assertStringContainsString('crowdsec_blocked_ips_active 1', $content);
+    }
+
+    public function test_metrics_contains_blocked_ips_total(): void
+    {
+        $response = $this->get('/crowdsec/metrics');
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('# TYPE crowdsec_blocked_ips_total counter', $content);
+        $this->assertStringContainsString('crowdsec_blocked_ips_total', $content);
+    }
+
+    public function test_metrics_contains_tracked_ips(): void
+    {
+        IpBehavior::create([
+            'ip' => '9.8.7.6',
+            'threat_score' => 25,
+            'request_count' => 5,
+        ]);
+
+        $response = $this->get('/crowdsec/metrics');
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('# TYPE crowdsec_tracked_ips gauge', $content);
+        $this->assertStringContainsString('crowdsec_tracked_ips 1', $content);
+    }
+
+    public function test_metrics_contains_high_threat_ips(): void
+    {
+        $response = $this->get('/crowdsec/metrics');
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('# TYPE crowdsec_high_threat_ips gauge', $content);
+        $this->assertStringContainsString('crowdsec_high_threat_ips', $content);
+    }
+
+    public function test_metrics_contains_threat_score_average(): void
+    {
+        $response = $this->get('/crowdsec/metrics');
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('# TYPE crowdsec_threat_score_average gauge', $content);
+        $this->assertStringContainsString('crowdsec_threat_score_average', $content);
+    }
+
+    public function test_metrics_contains_events_today(): void
+    {
+        $response = $this->get('/crowdsec/metrics');
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('# TYPE crowdsec_events_today gauge', $content);
+        $this->assertStringContainsString('crowdsec_events_today', $content);
+    }
+
+    public function test_metrics_contains_events_this_hour(): void
+    {
+        $response = $this->get('/crowdsec/metrics');
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('# TYPE crowdsec_events_this_hour gauge', $content);
+        $this->assertStringContainsString('crowdsec_events_this_hour', $content);
+    }
+
+    public function test_metrics_labels_are_sanitized(): void
+    {
+        SecurityEvent::create([
+            'ip' => '1.1.1.1',
+            'event_type' => 'xss-attack/reflected',
+            'severity' => 'high',
+            'description' => 'test',
+        ]);
+
+        $response = $this->get('/crowdsec/metrics');
+        $content = $response->getContent();
+
+        // Slashes and hyphens should be replaced with underscores
+        $this->assertStringContainsString('type="xss_attack_reflected"', $content);
+    }
+
+    public function test_metrics_with_empty_database(): void
+    {
+        $response = $this->get('/crowdsec/metrics');
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('crowdsec_blocked_ips_active 0', $content);
+        $this->assertStringContainsString('crowdsec_blocked_ips_total 0', $content);
+        $this->assertStringContainsString('crowdsec_tracked_ips 0', $content);
+        $this->assertStringContainsString('crowdsec_events_today 0', $content);
+    }
+
+    public function test_metrics_multiple_threat_types(): void
+    {
+        SecurityEvent::create([
+            'ip' => '1.1.1.1',
+            'event_type' => 'sql_injection',
+            'severity' => 'critical',
+            'description' => 'test',
+        ]);
+        SecurityEvent::create([
+            'ip' => '2.2.2.2',
+            'event_type' => 'xss',
+            'severity' => 'high',
+            'description' => 'test',
+        ]);
+        SecurityEvent::create([
+            'ip' => '3.3.3.3',
+            'event_type' => 'sql_injection',
+            'severity' => 'critical',
+            'description' => 'test',
+        ]);
+
+        $response = $this->get('/crowdsec/metrics');
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('crowdsec_threats_total{type="sql_injection",severity="critical"} 2', $content);
+        $this->assertStringContainsString('crowdsec_threats_total{type="xss",severity="high"} 1', $content);
+    }
+}


### PR DESCRIPTION
## Summary

Prometheus-compatible metrics endpoint for monitoring integration.

Closes #48

## Changes
- `CrowdSecMetricsController` — 8 metrics in OpenMetrics format
- Route, config (`crowdsec-scenarios.metrics`), and label sanitization
- 12 new tests (165 total, 297 assertions)

## Metrics
```
crowdsec_threats_total{type,severity}  (counter)
crowdsec_blocked_ips_active            (gauge)
crowdsec_blocked_ips_total             (counter)
crowdsec_tracked_ips                   (gauge)
crowdsec_high_threat_ips               (gauge)
crowdsec_threat_score_average          (gauge)
crowdsec_events_today                  (gauge)
crowdsec_events_this_hour              (gauge)
```